### PR TITLE
feat: Add Release composite action

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,5 +97,5 @@ jobs:
           gh_rw_token: ${{ secrets.GH_RW_TOKEN }}
           publish_token: ${{ secrets.NPM_CI_PUBLISH_TOKEN }}
           chromatic_project_token: ${{ secrets.CHROMATIC_APP_CODE }}
-          node_version: '14.x'
+          version: 'minor'
 ```

--- a/README.md
+++ b/README.md
@@ -79,3 +79,23 @@ jobs:
           slackMessage: |
             Release job failed. Please check error logs.
 ```
+
+### `release`
+
+Makes release based on given version or patch as default.
+
+#### Example
+```yml
+jobs:
+  main:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: Workday/canvas-kit-actions/release@v1
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          gh_rw_token: ${{ secrets.GH_RW_TOKEN }}
+          publish_token: ${{ secrets.NPM_CI_PUBLISH_TOKEN }}
+          chromatic_project_token: ${{ secrets.CHROMATIC_APP_CODE }}
+          node_version: '14.x'
+```

--- a/release/action.yml
+++ b/release/action.yml
@@ -102,6 +102,7 @@ runs:
     ## Capture the new tag and store it for later use
     - name: Get new tag
       id: new-tag
+      shell: bash
       run: echo "::set-output name=tag::$(node -p 'require("./lerna.json").version')"
 
     ## Generate a changeset based on rules of the Canvas Kit repository

--- a/release/action.yml
+++ b/release/action.yml
@@ -14,13 +14,6 @@ inputs:
   chromatic_project_token:
     required: true
     description: 'Chromatic project token to deploy a storybook.'
-  slack_webhook:
-    required: true
-    description: 'Slack webhook token to connect to make requests to Slack API'
-  node_version:
-    required: false
-    description: 'Version of Node'
-    default: '14.x'
   version:
     required: false
     description: 'The version override (example: "8.1.2"). Leave blank if you want to make patch release.'
@@ -29,42 +22,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    ## This step installs node and sets up several matchers (regex matching for Github
-    ## Annotations). See
-    ## https://github.com/actions/setup-node/blob/25316bbc1f10ac9d8798711f44914b1cf3c4e954/src/main.ts#L58-L65
-    - uses: actions/setup-node@v2.4.0
-      with:
-        node-version: ${{ inputs.node_version }}
-        registry-url: https://registry.npmjs.org
-
-    ## The caching steps create a cache key based on the OS and hash of the yarn.lock file. A
-    ## cache hit will copy files from Github cache into the `node_modules` and `.cache/cypress`
-    ## folders. A cache hit will skip the cache steps
-    - name: Cache node modules
-      id: yarn-cache
-      uses: actions/cache@v2
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node-modules-hash-${{ hashFiles('yarn.lock') }}
-
-    - name: Cache Cypress
-      id: cypress-cache
-      uses: actions/cache/@v2
-      with:
-        path: .cache/cypress
-        key: ${{ runner.os }}-cypress-cache-version-${{ steps.cypress-version.outputs.version }}
-
-    ## If both `node_modules` and `.cache/cypress` were cache hits, we're going to skip the `yarn
-    ## install` step. This effectively saves up to 3m on a cache hit build.
-    - name: Install Packages
-      if:
-        steps.yarn-cache.outputs.cache-hit != 'true' || steps.cypress-cache.outputs.cache-hit !=
-        'true'
-      shell: bash
-      run: yarn install --production=false
-      env:
-        CYPRESS_CACHE_FOLDER: .cache/cypress
-
     ## A `yarn bump` will create a commit and a tag. We need to set up the git user to do this.
     ## We'll make that user be the github-actions user.
     - name: Config git user
@@ -194,15 +151,3 @@ runs:
         exitOnceUploaded: true
         exitZeroOnChanges: true
         autoAcceptChanges: true
-
-    ## Notify Slack of any failures
-    - name: Report failures
-      if: ${{ failure() }}
-      shell: bash
-      run: node utils/report-failure.mjs
-      env:
-        SLACK_WEBHOOK: ${{ inputs.slack_webhook }}
-        TRAVIS_BRANCH: ${{ steps.extract-branch.outputs.branch }}
-        TRAVIS_TEST_RESULT: ${{ job.status }}
-        TRAVIS_BUILD_URL:
-          ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/release/action.yml
+++ b/release/action.yml
@@ -68,8 +68,8 @@ runs:
       if:
         steps.yarn-cache.outputs.cache-hit != 'true' || steps.cypress-cache.outputs.cache-hit !=
         'true'
-      run: yarn install --production=false
       shell: bash
+      run: yarn install --production=false
       env:
         CYPRESS_CACHE_FOLDER: .cache/cypress
 
@@ -96,14 +96,13 @@ runs:
 
     ## Manual version override, patch as default
     - name: Lerna Bump
-      run: yarn bump --yes ${{inputs.version}}
       shell: bash
+      run: yarn bump --yes ${{inputs.version}}
 
     ## Capture the new tag and store it for later use
     - name: Get new tag
       id: new-tag
       run: echo "::set-output name=tag::$(node -p 'require("./lerna.json").version')"
-      shell: bash
 
     ## Generate a changeset based on rules of the Canvas Kit repository
     - name: Generate Changeset
@@ -118,8 +117,8 @@ runs:
     ## We could have gone the route of a lerna changeset plugin, but we would lose access to
     ## usernames which add a nice human touch to release notes
     - name: Update Changelog
-      run: node utils/update-changelog.js
       shell: bash
+      run: node utils/update-changelog.js
       env:
         CHANGESET_TITLE: ${{steps.changeset.outputs.title}}
         CHANGESET_BODY: |
@@ -128,29 +127,32 @@ runs:
     ## So far, the changes to to the workspace have not been committed. We'll commit them now and
     ## create a tag
     - name: Commit and add Tag
+      shell: bash
       run: |
         git add . && git commit -m "chore: Release v${{steps.new-tag.outputs.tag}} [skip release]" && git tag -a v${{steps.new-tag.outputs.tag}} -m "v${{steps.new-tag.outputs.tag}}"
-      shell: bash
 
     - name: See git log
+      shell: bash
       run: |
         git log -n 1 --decorate=short
-      shell: bash
 
     # Build Storybook and extract component stories for Storybook aggregation. This will be used
     # for Chromatic rebaselining and publishing to GH Pages. Should be before `yarn build` since
     # built assets mess up this command
     - name: Build Storybook
+      shell: bash
       run: |
         yarn build-storybook --quiet
         npx sb extract docs docs/stories.json
 
     ## Build for packaging.
     - name: Build
+      shell: bash
       run: yarn build
 
     # Publish to npm. Must be run after a build
     - name: Publish
+      shell: bash
       run:
         yarn lerna publish from-package --yes --dist-tag ${{steps.extract-branch.outputs.branch ==
         'master' && 'latest' || 'support'}}
@@ -203,6 +205,7 @@ runs:
     ## Notify Slack of any failures
     - name: Report failures
       if: ${{ failure() }}
+      shell: bash
       run: node utils/report-failure.mjs
       env:
         SLACK_WEBHOOK: ${{ inputs.slack_webhook }}

--- a/release/action.yml
+++ b/release/action.yml
@@ -19,7 +19,7 @@ inputs:
     description: 'The version override (example: "8.1.2"). Leave blank if you want to make patch release.'
 
 runs:
-  using: 'node16'
+  using: 'composite'
   steps:
     ## First, we'll checkout the repository. We don't persist credentials because we need a
     ## Personal Access Token to push on a branch that is protected. See

--- a/release/action.yml
+++ b/release/action.yml
@@ -8,12 +8,12 @@ inputs:
   gh_rw_token:
     required: true
     description: 'A github token with write and read access to the repository'
-  publish_token:
-    required: true
-  chromatic_code:
-    required: true
-  slack_webhook:
-    required: true
+  # publish_token:
+  #   required: true
+  # chromatic_code:
+  #   required: true
+  # slack_webhook:
+  #   required: true
   version:
     required: false
     description: 'The version override (example: "8.1.2"). Leave blank if you want to make patch release.'
@@ -128,66 +128,66 @@ runs:
       ## Build Storybook and extract component stories for Storybook aggregation. This will be used
       ## for Chromatic rebaselining and publishing to GH Pages. Should be before `yarn build` since
       ## built assets mess up this command
-      - name: Build Storybook
-        run: |
-          yarn build-storybook --quiet
-          npx sb extract docs docs/stories.json
-      ## Build for packaging.
-      - name: Build
-        run: yarn build
+      # - name: Build Storybook
+      #   run: |
+      #     yarn build-storybook --quiet
+      #     npx sb extract docs docs/stories.json
+      # ## Build for packaging.
+      # - name: Build
+      #   run: yarn build
       ## Publish to npm. Must be run after a build
-      - name: Publish
-        run:
-          yarn lerna publish from-package --yes --dist-tag ${{steps.extract-branch.outputs.branch ==
-          'master' && 'latest' || 'support'}}
-        env:
-          NODE_AUTH_TOKEN: '${{inputs.publish_token}}'
-      # Push both the commit and tag created by Lerna's version command using a PAT
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ inputs.gh_rw_token }}
-          branch: ${{ github.ref }}
-          tags: true
-      ## Create a release on Github. This will trigger an internal Slack message
-      - name: Create Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ inputs.gh_token }}
-        with:
-          tag_name: v${{steps.new-tag.outputs.tag}}
-          release_name: v${{steps.new-tag.outputs.tag}}
-          body: |
-            ${{steps.changeset.outputs.body}}
-          draft: false
-          prerelease: false
-      ## The master branch is used for static Storybook documentation in the `gh-pages` branch.
-      - name: Publish Storybook
-        if: steps.extract-branch.outputs.branch == 'master'
-        uses: JamesIves/github-pages-deploy-action@4.1.5
-        with:
-          branch: gh-pages
-          folder: docs
-      ## Create a Chromatic baseline auto-accepting changes. Chromatic changes are already accepted
-      ## in PRs, so we don't need to manually approve them here again. This new baseline will be
-      ## used for future PRs. New PRs may show extra Chromatic changes until the "Update Branch"
-      ## button is used in PRs which will pull this new baseline.
-      - name: Update Chromatic Baseline
-        uses: chromaui/action@v1
-        with:
-          token: ${{ inputs.gh_token }}
-          projectToken: ${{ inputs.chromatic_code }}
-          storybookBuildDir: docs
-          exitOnceUploaded: true
-          exitZeroOnChanges: true
-          autoAcceptChanges: true
-      ## Notify Slack of any failures
-      - name: Report failures
-        if: ${{ failure() }}
-        run: node utils/report-failure.mjs
-        env:
-          SLACK_WEBHOOK: ${{ inputs.slack_webhook }}
-          TRAVIS_BRANCH: ${{ steps.extract-branch.outputs.branch }}
-          TRAVIS_TEST_RESULT: ${{ job.status }}
-          TRAVIS_BUILD_URL:
-            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      # - name: Publish
+      #   run:
+      #     yarn lerna publish from-package --yes --dist-tag ${{steps.extract-branch.outputs.branch ==
+      #     'master' && 'latest' || 'support'}}
+      #   env:
+      #     NODE_AUTH_TOKEN: '${{inputs.publish_token}}'
+      # # Push both the commit and tag created by Lerna's version command using a PAT
+      # - name: Push changes
+      #   uses: ad-m/github-push-action@master
+      #   with:
+      #     github_token: ${{ inputs.gh_rw_token }}
+      #     branch: ${{ github.ref }}
+      #     tags: true
+      # ## Create a release on Github. This will trigger an internal Slack message
+      # - name: Create Release
+      #   uses: actions/create-release@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ inputs.gh_token }}
+      #   with:
+      #     tag_name: v${{steps.new-tag.outputs.tag}}
+      #     release_name: v${{steps.new-tag.outputs.tag}}
+      #     body: |
+      #       ${{steps.changeset.outputs.body}}
+      #     draft: false
+      #     prerelease: false
+      # ## The master branch is used for static Storybook documentation in the `gh-pages` branch.
+      # - name: Publish Storybook
+      #   if: steps.extract-branch.outputs.branch == 'master'
+      #   uses: JamesIves/github-pages-deploy-action@4.1.5
+      #   with:
+      #     branch: gh-pages
+      #     folder: docs
+      # ## Create a Chromatic baseline auto-accepting changes. Chromatic changes are already accepted
+      # ## in PRs, so we don't need to manually approve them here again. This new baseline will be
+      # ## used for future PRs. New PRs may show extra Chromatic changes until the "Update Branch"
+      # ## button is used in PRs which will pull this new baseline.
+      # - name: Update Chromatic Baseline
+      #   uses: chromaui/action@v1
+      #   with:
+      #     token: ${{ inputs.gh_token }}
+      #     projectToken: ${{ inputs.chromatic_code }}
+      #     storybookBuildDir: docs
+      #     exitOnceUploaded: true
+      #     exitZeroOnChanges: true
+      #     autoAcceptChanges: true
+      # ## Notify Slack of any failures
+      # - name: Report failures
+      #   if: ${{ failure() }}
+      #   run: node utils/report-failure.mjs
+      #   env:
+      #     SLACK_WEBHOOK: ${{ inputs.slack_webhook }}
+      #     TRAVIS_BRANCH: ${{ steps.extract-branch.outputs.branch }}
+      #     TRAVIS_TEST_RESULT: ${{ job.status }}
+      #     TRAVIS_BUILD_URL:
+      #       ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/release/action.yml
+++ b/release/action.yml
@@ -19,6 +19,7 @@ inputs:
     description: 'The version override (example: "8.1.2"). Leave blank if you want to make patch release.'
 
 runs:
+  using: 'node16'
   steps:
     ## First, we'll checkout the repository. We don't persist credentials because we need a
     ## Personal Access Token to push on a branch that is protected. See

--- a/release/action.yml
+++ b/release/action.yml
@@ -19,175 +19,174 @@ inputs:
     description: 'The version override (example: "8.1.2"). Leave blank if you want to make patch release.'
 
 runs:
-  - name: Check inputs value
-        run: echo "${{ inputs.version }}"
-      ## First, we'll checkout the repository. We don't persist credentials because we need a
-      ## Personal Access Token to push on a branch that is protected. See
-      ## https://github.com/cycjimmy/semantic-release-action#basic-usage
-      - uses: actions/checkout@v2
-        with:
-          persist-credentials: false
-          fetch-depth: 0 # Used for conventional commit ranges
+  steps:
+    ## First, we'll checkout the repository. We don't persist credentials because we need a
+    ## Personal Access Token to push on a branch that is protected. See
+    ## https://github.com/cycjimmy/semantic-release-action#basic-usage
+    - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+        fetch-depth: 0 # Used for conventional commit ranges
 
-      ## This step installs node and sets up several matchers (regex matching for Github
-      ## Annotations). See
-      ## https://github.com/actions/setup-node/blob/25316bbc1f10ac9d8798711f44914b1cf3c4e954/src/main.ts#L58-L65
-      - uses: actions/setup-node@v2.4.0
-        with:
-          node-version: 14.x
-          registry-url: https://registry.npmjs.org
+    ## This step installs node and sets up several matchers (regex matching for Github
+    ## Annotations). See
+    ## https://github.com/actions/setup-node/blob/25316bbc1f10ac9d8798711f44914b1cf3c4e954/src/main.ts#L58-L65
+    - uses: actions/setup-node@v2.4.0
+      with:
+        node-version: 14.x
+        registry-url: https://registry.npmjs.org
 
-      ## The caching steps create a cache key based on the OS and hash of the yarn.lock file. A
-      ## cache hit will copy files from Github cache into the `node_modules` and `.cache/cypress`
-      ## folders. A cache hit will skip the cache steps
-      - name: Cache node modules
-        id: yarn-cache
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-hash-${{ hashFiles('yarn.lock') }}
+    ## The caching steps create a cache key based on the OS and hash of the yarn.lock file. A
+    ## cache hit will copy files from Github cache into the `node_modules` and `.cache/cypress`
+    ## folders. A cache hit will skip the cache steps
+    - name: Cache node modules
+      id: yarn-cache
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-modules-hash-${{ hashFiles('yarn.lock') }}
 
-      - name: Cache Cypress
-        id: cypress-cache
-        uses: actions/cache/@v2
-        with:
-          path: .cache/cypress
-          key: ${{ runner.os }}-cypress-cache-version-${{ steps.cypress-version.outputs.version }}
+    - name: Cache Cypress
+      id: cypress-cache
+      uses: actions/cache/@v2
+      with:
+        path: .cache/cypress
+        key: ${{ runner.os }}-cypress-cache-version-${{ steps.cypress-version.outputs.version }}
 
-      ## If both `node_modules` and `.cache/cypress` were cache hits, we're going to skip the `yarn
-      ## install` step. This effectively saves up to 3m on a cache hit build.
-      - name: Install Packages
-        if:
-          steps.yarn-cache.outputs.cache-hit != 'true' || steps.cypress-cache.outputs.cache-hit !=
-          'true'
-        run: yarn install --production=false
-        env:
-          CYPRESS_CACHE_FOLDER: .cache/cypress
+    ## If both `node_modules` and `.cache/cypress` were cache hits, we're going to skip the `yarn
+    ## install` step. This effectively saves up to 3m on a cache hit build.
+    - name: Install Packages
+      if:
+        steps.yarn-cache.outputs.cache-hit != 'true' || steps.cypress-cache.outputs.cache-hit !=
+        'true'
+      run: yarn install --production=false
+      env:
+        CYPRESS_CACHE_FOLDER: .cache/cypress
 
-      ## A `yarn bump` will create a commit and a tag. We need to set up the git user to do this.
-      ## We'll make that user be the github-actions user.
-      - name: Config git user
-        run: |
-          git config --global user.name "${{ github.actor }}"
-          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+    ## A `yarn bump` will create a commit and a tag. We need to set up the git user to do this.
+    ## We'll make that user be the github-actions user.
+    - name: Config git user
+      run: |
+        git config --global user.name "${{ github.actor }}"
+        git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
-      ## Capture the previous tag and store it for later use
-      - name: Get previous tag
-        id: previous-tag
-        run: echo "::set-output name=tag::$(node -p 'require("./lerna.json").version')"
+    ## Capture the previous tag and store it for later use
+    - name: Get previous tag
+      id: previous-tag
+      run: echo "::set-output name=tag::$(node -p 'require("./lerna.json").version')"
 
-      ## `github.ref` is in the form of `refs/head/{name}`. This step extracts `{name}` and saves it
-      ## as an output for later use
-      - name: Extract branch name
-        id: extract-branch
-        run: echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
+    ## `github.ref` is in the form of `refs/head/{name}`. This step extracts `{name}` and saves it
+    ## as an output for later use
+    - name: Extract branch name
+      id: extract-branch
+      run: echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
 
-      ## On the master branch, we'll do a patch bump on every commit by default.
-      - name: Lerna Bump
-        if: '!inputs.version'
-        run: yarn bump --yes patch
+    ## On the master branch, we'll do a patch bump on every commit by default.
+    - name: Lerna Bump
+      if: '!inputs.version'
+      run: yarn bump --yes patch
 
-      ## Manual version override
-      - name: Lerna Bump
-        if: 'inputs.version'
-        run: yarn bump --yes ${{inputs.version}}
+    ## Manual version override
+    - name: Lerna Bump
+      if: 'inputs.version'
+      run: yarn bump --yes ${{inputs.version}}
 
-      ## Capture the new tag and store it for later use
-      - name: Get new tag
-        id: new-tag
-        run: echo "::set-output name=tag::$(node -p 'require("./lerna.json").version')"
+    ## Capture the new tag and store it for later use
+    - name: Get new tag
+      id: new-tag
+      run: echo "::set-output name=tag::$(node -p 'require("./lerna.json").version')"
 
-      ## Generate a changeset based on rules of the Canvas Kit repository
-      - name: Generate Changeset
-        uses: Workday/canvas-kit-actions/generate-changeset@v1
-        id: changeset
-        with:
-          token: ${{ inputs.gh_token }}
-          fromRef: v${{steps.previous-tag.outputs.tag}}
-          toRef: ${{steps.extract-branch.outputs.branch}}
-          tagName: v${{steps.new-tag.outputs.tag}}
+    ## Generate a changeset based on rules of the Canvas Kit repository
+    - name: Generate Changeset
+      uses: Workday/canvas-kit-actions/generate-changeset@v1
+      id: changeset
+      with:
+        token: ${{ inputs.gh_token }}
+        fromRef: v${{steps.previous-tag.outputs.tag}}
+        toRef: ${{steps.extract-branch.outputs.branch}}
+        tagName: v${{steps.new-tag.outputs.tag}}
 
-      ## We could have gone the route of a lerna changeset plugin, but we would lose access to
-      ## usernames which add a nice human touch to release notes
-      - name: Update Changelog
-        run: node utils/update-changelog.js
-        env:
-          CHANGESET_TITLE: ${{steps.changeset.outputs.title}}
-          CHANGESET_BODY: |
-            ${{steps.changeset.outputs.body}}
+    ## We could have gone the route of a lerna changeset plugin, but we would lose access to
+    ## usernames which add a nice human touch to release notes
+    - name: Update Changelog
+      run: node utils/update-changelog.js
+      env:
+        CHANGESET_TITLE: ${{steps.changeset.outputs.title}}
+        CHANGESET_BODY: |
+          ${{steps.changeset.outputs.body}}
 
-      ## So far, the changes to to the workspace have not been committed. We'll commit them now and
-      ## create a tag
-      - name: Commit and add Tag
-        run: |
-          git add . && git commit -m "chore: Release v${{steps.new-tag.outputs.tag}} [skip release]" && git tag -a v${{steps.new-tag.outputs.tag}} -m "v${{steps.new-tag.outputs.tag}}"
+    ## So far, the changes to to the workspace have not been committed. We'll commit them now and
+    ## create a tag
+    - name: Commit and add Tag
+      run: |
+        git add . && git commit -m "chore: Release v${{steps.new-tag.outputs.tag}} [skip release]" && git tag -a v${{steps.new-tag.outputs.tag}} -m "v${{steps.new-tag.outputs.tag}}"
 
-      - name: See git log
-        run: |
-          git log -n 1 --decorate=short
-      ## Build Storybook and extract component stories for Storybook aggregation. This will be used
-      ## for Chromatic rebaselining and publishing to GH Pages. Should be before `yarn build` since
-      ## built assets mess up this command
-      # - name: Build Storybook
-      #   run: |
-      #     yarn build-storybook --quiet
-      #     npx sb extract docs docs/stories.json
-      # ## Build for packaging.
-      # - name: Build
-      #   run: yarn build
-      ## Publish to npm. Must be run after a build
-      # - name: Publish
-      #   run:
-      #     yarn lerna publish from-package --yes --dist-tag ${{steps.extract-branch.outputs.branch ==
-      #     'master' && 'latest' || 'support'}}
-      #   env:
-      #     NODE_AUTH_TOKEN: '${{inputs.publish_token}}'
-      # # Push both the commit and tag created by Lerna's version command using a PAT
-      # - name: Push changes
-      #   uses: ad-m/github-push-action@master
-      #   with:
-      #     github_token: ${{ inputs.gh_rw_token }}
-      #     branch: ${{ github.ref }}
-      #     tags: true
-      # ## Create a release on Github. This will trigger an internal Slack message
-      # - name: Create Release
-      #   uses: actions/create-release@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ inputs.gh_token }}
-      #   with:
-      #     tag_name: v${{steps.new-tag.outputs.tag}}
-      #     release_name: v${{steps.new-tag.outputs.tag}}
-      #     body: |
-      #       ${{steps.changeset.outputs.body}}
-      #     draft: false
-      #     prerelease: false
-      # ## The master branch is used for static Storybook documentation in the `gh-pages` branch.
-      # - name: Publish Storybook
-      #   if: steps.extract-branch.outputs.branch == 'master'
-      #   uses: JamesIves/github-pages-deploy-action@4.1.5
-      #   with:
-      #     branch: gh-pages
-      #     folder: docs
-      # ## Create a Chromatic baseline auto-accepting changes. Chromatic changes are already accepted
-      # ## in PRs, so we don't need to manually approve them here again. This new baseline will be
-      # ## used for future PRs. New PRs may show extra Chromatic changes until the "Update Branch"
-      # ## button is used in PRs which will pull this new baseline.
-      # - name: Update Chromatic Baseline
-      #   uses: chromaui/action@v1
-      #   with:
-      #     token: ${{ inputs.gh_token }}
-      #     projectToken: ${{ inputs.chromatic_code }}
-      #     storybookBuildDir: docs
-      #     exitOnceUploaded: true
-      #     exitZeroOnChanges: true
-      #     autoAcceptChanges: true
-      # ## Notify Slack of any failures
-      # - name: Report failures
-      #   if: ${{ failure() }}
-      #   run: node utils/report-failure.mjs
-      #   env:
-      #     SLACK_WEBHOOK: ${{ inputs.slack_webhook }}
-      #     TRAVIS_BRANCH: ${{ steps.extract-branch.outputs.branch }}
-      #     TRAVIS_TEST_RESULT: ${{ job.status }}
-      #     TRAVIS_BUILD_URL:
-      #       ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    - name: See git log
+      run: |
+        git log -n 1 --decorate=short
+    ## Build Storybook and extract component stories for Storybook aggregation. This will be used
+    ## for Chromatic rebaselining and publishing to GH Pages. Should be before `yarn build` since
+    ## built assets mess up this command
+    # - name: Build Storybook
+    #   run: |
+    #     yarn build-storybook --quiet
+    #     npx sb extract docs docs/stories.json
+    # ## Build for packaging.
+    # - name: Build
+    #   run: yarn build
+    ## Publish to npm. Must be run after a build
+    # - name: Publish
+    #   run:
+    #     yarn lerna publish from-package --yes --dist-tag ${{steps.extract-branch.outputs.branch ==
+    #     'master' && 'latest' || 'support'}}
+    #   env:
+    #     NODE_AUTH_TOKEN: '${{inputs.publish_token}}'
+    # # Push both the commit and tag created by Lerna's version command using a PAT
+    # - name: Push changes
+    #   uses: ad-m/github-push-action@master
+    #   with:
+    #     github_token: ${{ inputs.gh_rw_token }}
+    #     branch: ${{ github.ref }}
+    #     tags: true
+    # ## Create a release on Github. This will trigger an internal Slack message
+    # - name: Create Release
+    #   uses: actions/create-release@v1
+    #   env:
+    #     GITHUB_TOKEN: ${{ inputs.gh_token }}
+    #   with:
+    #     tag_name: v${{steps.new-tag.outputs.tag}}
+    #     release_name: v${{steps.new-tag.outputs.tag}}
+    #     body: |
+    #       ${{steps.changeset.outputs.body}}
+    #     draft: false
+    #     prerelease: false
+    # ## The master branch is used for static Storybook documentation in the `gh-pages` branch.
+    # - name: Publish Storybook
+    #   if: steps.extract-branch.outputs.branch == 'master'
+    #   uses: JamesIves/github-pages-deploy-action@4.1.5
+    #   with:
+    #     branch: gh-pages
+    #     folder: docs
+    # ## Create a Chromatic baseline auto-accepting changes. Chromatic changes are already accepted
+    # ## in PRs, so we don't need to manually approve them here again. This new baseline will be
+    # ## used for future PRs. New PRs may show extra Chromatic changes until the "Update Branch"
+    # ## button is used in PRs which will pull this new baseline.
+    # - name: Update Chromatic Baseline
+    #   uses: chromaui/action@v1
+    #   with:
+    #     token: ${{ inputs.gh_token }}
+    #     projectToken: ${{ inputs.chromatic_code }}
+    #     storybookBuildDir: docs
+    #     exitOnceUploaded: true
+    #     exitZeroOnChanges: true
+    #     autoAcceptChanges: true
+    # ## Notify Slack of any failures
+    # - name: Report failures
+    #   if: ${{ failure() }}
+    #   run: node utils/report-failure.mjs
+    #   env:
+    #     SLACK_WEBHOOK: ${{ inputs.slack_webhook }}
+    #     TRAVIS_BRANCH: ${{ steps.extract-branch.outputs.branch }}
+    #     TRAVIS_TEST_RESULT: ${{ job.status }}
+    #     TRAVIS_BUILD_URL:
+    #       ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/release/action.yml
+++ b/release/action.yml
@@ -1,0 +1,193 @@
+name: 'Release'
+description: 'Automate a release'
+author: 'Workday'
+inputs:
+  gh_token:
+    required: true
+    description: 'A github token with at least read access to the repository'
+  gh_rw_token:
+    required: true
+    description: 'A github token with write and read access to the repository'
+  publish_token:
+    required: true
+  chromatic_code:
+    required: true
+  slack_webhook:
+    required: true
+  version:
+    required: false
+    description: 'The version override (example: "8.1.2"). Leave blank if you want to make patch release.'
+
+runs:
+  - name: Check inputs value
+        run: echo "${{ inputs.version }}"
+      ## First, we'll checkout the repository. We don't persist credentials because we need a
+      ## Personal Access Token to push on a branch that is protected. See
+      ## https://github.com/cycjimmy/semantic-release-action#basic-usage
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          fetch-depth: 0 # Used for conventional commit ranges
+
+      ## This step installs node and sets up several matchers (regex matching for Github
+      ## Annotations). See
+      ## https://github.com/actions/setup-node/blob/25316bbc1f10ac9d8798711f44914b1cf3c4e954/src/main.ts#L58-L65
+      - uses: actions/setup-node@v2.4.0
+        with:
+          node-version: 14.x
+          registry-url: https://registry.npmjs.org
+
+      ## The caching steps create a cache key based on the OS and hash of the yarn.lock file. A
+      ## cache hit will copy files from Github cache into the `node_modules` and `.cache/cypress`
+      ## folders. A cache hit will skip the cache steps
+      - name: Cache node modules
+        id: yarn-cache
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-hash-${{ hashFiles('yarn.lock') }}
+
+      - name: Cache Cypress
+        id: cypress-cache
+        uses: actions/cache/@v2
+        with:
+          path: .cache/cypress
+          key: ${{ runner.os }}-cypress-cache-version-${{ steps.cypress-version.outputs.version }}
+
+      ## If both `node_modules` and `.cache/cypress` were cache hits, we're going to skip the `yarn
+      ## install` step. This effectively saves up to 3m on a cache hit build.
+      - name: Install Packages
+        if:
+          steps.yarn-cache.outputs.cache-hit != 'true' || steps.cypress-cache.outputs.cache-hit !=
+          'true'
+        run: yarn install --production=false
+        env:
+          CYPRESS_CACHE_FOLDER: .cache/cypress
+
+      ## A `yarn bump` will create a commit and a tag. We need to set up the git user to do this.
+      ## We'll make that user be the github-actions user.
+      - name: Config git user
+        run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+
+      ## Capture the previous tag and store it for later use
+      - name: Get previous tag
+        id: previous-tag
+        run: echo "::set-output name=tag::$(node -p 'require("./lerna.json").version')"
+
+      ## `github.ref` is in the form of `refs/head/{name}`. This step extracts `{name}` and saves it
+      ## as an output for later use
+      - name: Extract branch name
+        id: extract-branch
+        run: echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
+
+      ## On the master branch, we'll do a patch bump on every commit by default.
+      - name: Lerna Bump
+        if: '!inputs.version'
+        run: yarn bump --yes patch
+
+      ## Manual version override
+      - name: Lerna Bump
+        if: 'inputs.version'
+        run: yarn bump --yes ${{inputs.version}}
+
+      ## Capture the new tag and store it for later use
+      - name: Get new tag
+        id: new-tag
+        run: echo "::set-output name=tag::$(node -p 'require("./lerna.json").version')"
+
+      ## Generate a changeset based on rules of the Canvas Kit repository
+      - name: Generate Changeset
+        uses: Workday/canvas-kit-actions/generate-changeset@v1
+        id: changeset
+        with:
+          token: ${{ inputs.gh_token }}
+          fromRef: v${{steps.previous-tag.outputs.tag}}
+          toRef: ${{steps.extract-branch.outputs.branch}}
+          tagName: v${{steps.new-tag.outputs.tag}}
+
+      ## We could have gone the route of a lerna changeset plugin, but we would lose access to
+      ## usernames which add a nice human touch to release notes
+      - name: Update Changelog
+        run: node utils/update-changelog.js
+        env:
+          CHANGESET_TITLE: ${{steps.changeset.outputs.title}}
+          CHANGESET_BODY: |
+            ${{steps.changeset.outputs.body}}
+
+      ## So far, the changes to to the workspace have not been committed. We'll commit them now and
+      ## create a tag
+      - name: Commit and add Tag
+        run: |
+          git add . && git commit -m "chore: Release v${{steps.new-tag.outputs.tag}} [skip release]" && git tag -a v${{steps.new-tag.outputs.tag}} -m "v${{steps.new-tag.outputs.tag}}"
+
+      - name: See git log
+        run: |
+          git log -n 1 --decorate=short
+      ## Build Storybook and extract component stories for Storybook aggregation. This will be used
+      ## for Chromatic rebaselining and publishing to GH Pages. Should be before `yarn build` since
+      ## built assets mess up this command
+      - name: Build Storybook
+        run: |
+          yarn build-storybook --quiet
+          npx sb extract docs docs/stories.json
+      ## Build for packaging.
+      - name: Build
+        run: yarn build
+      ## Publish to npm. Must be run after a build
+      - name: Publish
+        run:
+          yarn lerna publish from-package --yes --dist-tag ${{steps.extract-branch.outputs.branch ==
+          'master' && 'latest' || 'support'}}
+        env:
+          NODE_AUTH_TOKEN: '${{inputs.publish_token}}'
+      # Push both the commit and tag created by Lerna's version command using a PAT
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ inputs.gh_rw_token }}
+          branch: ${{ github.ref }}
+          tags: true
+      ## Create a release on Github. This will trigger an internal Slack message
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ inputs.gh_token }}
+        with:
+          tag_name: v${{steps.new-tag.outputs.tag}}
+          release_name: v${{steps.new-tag.outputs.tag}}
+          body: |
+            ${{steps.changeset.outputs.body}}
+          draft: false
+          prerelease: false
+      ## The master branch is used for static Storybook documentation in the `gh-pages` branch.
+      - name: Publish Storybook
+        if: steps.extract-branch.outputs.branch == 'master'
+        uses: JamesIves/github-pages-deploy-action@4.1.5
+        with:
+          branch: gh-pages
+          folder: docs
+      ## Create a Chromatic baseline auto-accepting changes. Chromatic changes are already accepted
+      ## in PRs, so we don't need to manually approve them here again. This new baseline will be
+      ## used for future PRs. New PRs may show extra Chromatic changes until the "Update Branch"
+      ## button is used in PRs which will pull this new baseline.
+      - name: Update Chromatic Baseline
+        uses: chromaui/action@v1
+        with:
+          token: ${{ inputs.gh_token }}
+          projectToken: ${{ inputs.chromatic_code }}
+          storybookBuildDir: docs
+          exitOnceUploaded: true
+          exitZeroOnChanges: true
+          autoAcceptChanges: true
+      ## Notify Slack of any failures
+      - name: Report failures
+        if: ${{ failure() }}
+        run: node utils/report-failure.mjs
+        env:
+          SLACK_WEBHOOK: ${{ inputs.slack_webhook }}
+          TRAVIS_BRANCH: ${{ steps.extract-branch.outputs.branch }}
+          TRAVIS_TEST_RESULT: ${{ job.status }}
+          TRAVIS_BUILD_URL:
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/release/action.yml
+++ b/release/action.yml
@@ -105,108 +105,108 @@ runs:
       run: echo "::set-output name=tag::$(node -p 'require("./lerna.json").version')"
       shell: bash
 
-    # ## Generate a changeset based on rules of the Canvas Kit repository
-    # - name: Generate Changeset
-    #   uses: Workday/canvas-kit-actions/generate-changeset@v1
-    #   id: changeset
-    #   with:
-    #     token: ${{ inputs.gh_token }}
-    #     fromRef: v${{steps.previous-tag.outputs.tag}}
-    #     toRef: ${{steps.extract-branch.outputs.branch}}
-    #     tagName: v${{steps.new-tag.outputs.tag}}
+    ## Generate a changeset based on rules of the Canvas Kit repository
+    - name: Generate Changeset
+      uses: Workday/canvas-kit-actions/generate-changeset@v1
+      id: changeset
+      with:
+        token: ${{ inputs.gh_token }}
+        fromRef: v${{steps.previous-tag.outputs.tag}}
+        toRef: ${{steps.extract-branch.outputs.branch}}
+        tagName: v${{steps.new-tag.outputs.tag}}
 
-    # ## We could have gone the route of a lerna changeset plugin, but we would lose access to
-    # ## usernames which add a nice human touch to release notes
-    # - name: Update Changelog
-    #   run: node utils/update-changelog.js
-    #   shell: bash
-    #   env:
-    #     CHANGESET_TITLE: ${{steps.changeset.outputs.title}}
-    #     CHANGESET_BODY: |
-    #       ${{steps.changeset.outputs.body}}
+    ## We could have gone the route of a lerna changeset plugin, but we would lose access to
+    ## usernames which add a nice human touch to release notes
+    - name: Update Changelog
+      run: node utils/update-changelog.js
+      shell: bash
+      env:
+        CHANGESET_TITLE: ${{steps.changeset.outputs.title}}
+        CHANGESET_BODY: |
+          ${{steps.changeset.outputs.body}}
 
-    # ## So far, the changes to to the workspace have not been committed. We'll commit them now and
-    # ## create a tag
-    # - name: Commit and add Tag
-    #   run: |
-    #     git add . && git commit -m "chore: Release v${{steps.new-tag.outputs.tag}} [skip release]" && git tag -a v${{steps.new-tag.outputs.tag}} -m "v${{steps.new-tag.outputs.tag}}"
-    #   shell: bash
+    ## So far, the changes to to the workspace have not been committed. We'll commit them now and
+    ## create a tag
+    - name: Commit and add Tag
+      run: |
+        git add . && git commit -m "chore: Release v${{steps.new-tag.outputs.tag}} [skip release]" && git tag -a v${{steps.new-tag.outputs.tag}} -m "v${{steps.new-tag.outputs.tag}}"
+      shell: bash
 
-    # - name: See git log
-    #   run: |
-    #     git log -n 1 --decorate=short
-    #   shell: bash
+    - name: See git log
+      run: |
+        git log -n 1 --decorate=short
+      shell: bash
 
-    # # Build Storybook and extract component stories for Storybook aggregation. This will be used
-    # # for Chromatic rebaselining and publishing to GH Pages. Should be before `yarn build` since
-    # # built assets mess up this command
-    # - name: Build Storybook
-    #   run: |
-    #     yarn build-storybook --quiet
-    #     npx sb extract docs docs/stories.json
+    # Build Storybook and extract component stories for Storybook aggregation. This will be used
+    # for Chromatic rebaselining and publishing to GH Pages. Should be before `yarn build` since
+    # built assets mess up this command
+    - name: Build Storybook
+      run: |
+        yarn build-storybook --quiet
+        npx sb extract docs docs/stories.json
 
-    # ## Build for packaging.
-    # - name: Build
-    #   run: yarn build
+    ## Build for packaging.
+    - name: Build
+      run: yarn build
 
-    # # Publish to npm. Must be run after a build
-    # - name: Publish
-    #   run:
-    #     yarn lerna publish from-package --yes --dist-tag ${{steps.extract-branch.outputs.branch ==
-    #     'master' && 'latest' || 'support'}}
-    #   env:
-    #     NODE_AUTH_TOKEN: '${{inputs.publish_token}}'
+    # Publish to npm. Must be run after a build
+    - name: Publish
+      run:
+        yarn lerna publish from-package --yes --dist-tag ${{steps.extract-branch.outputs.branch ==
+        'master' && 'latest' || 'support'}}
+      env:
+        NODE_AUTH_TOKEN: '${{inputs.publish_token}}'
 
-    # # Push both the commit and tag created by Lerna's version command using a PAT
-    # - name: Push changes
-    #   uses: ad-m/github-push-action@master
-    #   with:
-    #     github_token: ${{ inputs.gh_rw_token }}
-    #     branch: ${{ github.ref }}
-    #     tags: true
+    # Push both the commit and tag created by Lerna's version command using a PAT
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ inputs.gh_rw_token }}
+        branch: ${{ github.ref }}
+        tags: true
 
-    # ## Create a release on Github. This will trigger an internal Slack message
-    # - name: Create Release
-    #   uses: actions/create-release@v1
-    #   env:
-    #     GITHUB_TOKEN: ${{ inputs.gh_token }}
-    #   with:
-    #     tag_name: v${{steps.new-tag.outputs.tag}}
-    #     release_name: v${{steps.new-tag.outputs.tag}}
-    #     body: |
-    #       ${{steps.changeset.outputs.body}}
-    #     draft: false
-    #     prerelease: false
+    ## Create a release on Github. This will trigger an internal Slack message
+    - name: Create Release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ inputs.gh_token }}
+      with:
+        tag_name: v${{steps.new-tag.outputs.tag}}
+        release_name: v${{steps.new-tag.outputs.tag}}
+        body: |
+          ${{steps.changeset.outputs.body}}
+        draft: false
+        prerelease: false
 
-    # ## The master branch is used for static Storybook documentation in the `gh-pages` branch.
-    # - name: Publish Storybook
-    #   if: steps.extract-branch.outputs.branch == 'master'
-    #   uses: JamesIves/github-pages-deploy-action@4.1.5
-    #   with:
-    #     branch: gh-pages
-    #     folder: docs
+    ## The master branch is used for static Storybook documentation in the `gh-pages` branch.
+    - name: Publish Storybook
+      if: steps.extract-branch.outputs.branch == 'master'
+      uses: JamesIves/github-pages-deploy-action@4.1.5
+      with:
+        branch: gh-pages
+        folder: docs
 
-    # ## Create a Chromatic baseline auto-accepting changes. Chromatic changes are already accepted
-    # ## in PRs, so we don't need to manually approve them here again. This new baseline will be
-    # ## used for future PRs. New PRs may show extra Chromatic changes until the "Update Branch"
-    # ## button is used in PRs which will pull this new baseline.
-    # - name: Update Chromatic Baseline
-    #   uses: chromaui/action@v1
-    #   with:
-    #     token: ${{ inputs.gh_token }}
-    #     projectToken: ${{ inputs.chromatic_code }}
-    #     storybookBuildDir: docs
-    #     exitOnceUploaded: true
-    #     exitZeroOnChanges: true
-    #     autoAcceptChanges: true
+    ## Create a Chromatic baseline auto-accepting changes. Chromatic changes are already accepted
+    ## in PRs, so we don't need to manually approve them here again. This new baseline will be
+    ## used for future PRs. New PRs may show extra Chromatic changes until the "Update Branch"
+    ## button is used in PRs which will pull this new baseline.
+    - name: Update Chromatic Baseline
+      uses: chromaui/action@v1
+      with:
+        token: ${{ inputs.gh_token }}
+        projectToken: ${{ inputs.chromatic_code }}
+        storybookBuildDir: docs
+        exitOnceUploaded: true
+        exitZeroOnChanges: true
+        autoAcceptChanges: true
 
-    # ## Notify Slack of any failures
-    # - name: Report failures
-    #   if: ${{ failure() }}
-    #   run: node utils/report-failure.mjs
-    #   env:
-    #     SLACK_WEBHOOK: ${{ inputs.slack_webhook }}
-    #     TRAVIS_BRANCH: ${{ steps.extract-branch.outputs.branch }}
-    #     TRAVIS_TEST_RESULT: ${{ job.status }}
-    #     TRAVIS_BUILD_URL:
-    #       ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    ## Notify Slack of any failures
+    - name: Report failures
+      if: ${{ failure() }}
+      run: node utils/report-failure.mjs
+      env:
+        SLACK_WEBHOOK: ${{ inputs.slack_webhook }}
+        TRAVIS_BRANCH: ${{ steps.extract-branch.outputs.branch }}
+        TRAVIS_TEST_RESULT: ${{ job.status }}
+        TRAVIS_BUILD_URL:
+          ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/release/action.yml
+++ b/release/action.yml
@@ -61,12 +61,14 @@ runs:
         steps.yarn-cache.outputs.cache-hit != 'true' || steps.cypress-cache.outputs.cache-hit !=
         'true'
       run: yarn install --production=false
+      shell: bash
       env:
         CYPRESS_CACHE_FOLDER: .cache/cypress
 
     ## A `yarn bump` will create a commit and a tag. We need to set up the git user to do this.
     ## We'll make that user be the github-actions user.
     - name: Config git user
+      shell: bash
       run: |
         git config --global user.name "${{ github.actor }}"
         git config --global user.email "${{ github.actor }}@users.noreply.github.com"
@@ -75,27 +77,32 @@ runs:
     - name: Get previous tag
       id: previous-tag
       run: echo "::set-output name=tag::$(node -p 'require("./lerna.json").version')"
+      shell: bash
 
     ## `github.ref` is in the form of `refs/head/{name}`. This step extracts `{name}` and saves it
     ## as an output for later use
     - name: Extract branch name
       id: extract-branch
       run: echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
+      shell: bash
 
     ## On the master branch, we'll do a patch bump on every commit by default.
     - name: Lerna Bump
       if: '!inputs.version'
       run: yarn bump --yes patch
+      shell: bash
 
     ## Manual version override
     - name: Lerna Bump
       if: 'inputs.version'
       run: yarn bump --yes ${{inputs.version}}
+      shell: bash
 
     ## Capture the new tag and store it for later use
     - name: Get new tag
       id: new-tag
       run: echo "::set-output name=tag::$(node -p 'require("./lerna.json").version')"
+      shell: bash
 
     ## Generate a changeset based on rules of the Canvas Kit repository
     - name: Generate Changeset
@@ -111,6 +118,7 @@ runs:
     ## usernames which add a nice human touch to release notes
     - name: Update Changelog
       run: node utils/update-changelog.js
+      shell: bash
       env:
         CHANGESET_TITLE: ${{steps.changeset.outputs.title}}
         CHANGESET_BODY: |
@@ -121,10 +129,12 @@ runs:
     - name: Commit and add Tag
       run: |
         git add . && git commit -m "chore: Release v${{steps.new-tag.outputs.tag}} [skip release]" && git tag -a v${{steps.new-tag.outputs.tag}} -m "v${{steps.new-tag.outputs.tag}}"
+      shell: bash
 
     - name: See git log
       run: |
         git log -n 1 --decorate=short
+      shell: bash
     ## Build Storybook and extract component stories for Storybook aggregation. This will be used
     ## for Chromatic rebaselining and publishing to GH Pages. Should be before `yarn build` since
     ## built assets mess up this command

--- a/release/action.yml
+++ b/release/action.yml
@@ -29,14 +29,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    ## First, we'll checkout the repository. We don't persist credentials because we need a
-    ## Personal Access Token to push on a branch that is protected. See
-    ## https://github.com/cycjimmy/semantic-release-action#basic-usage
-    - uses: actions/checkout@v2
-      with:
-        persist-credentials: false
-        fetch-depth: 0 # Used for conventional commit ranges
-
     ## This step installs node and sets up several matchers (regex matching for Github
     ## Annotations). See
     ## https://github.com/actions/setup-node/blob/25316bbc1f10ac9d8798711f44914b1cf3c4e954/src/main.ts#L58-L65

--- a/release/action.yml
+++ b/release/action.yml
@@ -4,19 +4,27 @@ author: 'Workday'
 inputs:
   gh_token:
     required: true
-    description: 'A github token with at least read access to the repository'
+    description: 'An authentication token for github.com API requests.'
   gh_rw_token:
     required: true
-    description: 'A github token with write and read access to the repository'
-  # publish_token:
-  #   required: true
-  # chromatic_code:
-  #   required: true
-  # slack_webhook:
-  #   required: true
+    description: 'A personal access token with read-write permissions.'
+  publish_token:
+    required: true
+    description: 'Environment variable which is required for authenticating with npm to publish the package.'
+  chromatic_project_token:
+    required: true
+    description: 'Chromatic project token to deploy a storybook.'
+  slack_webhook:
+    required: true
+    description: 'Slack webhook token to connect to make requests to Slack API'
+  node_version:
+    required: false
+    description: 'Version of Node'
+    default: '14.x'
   version:
     required: false
     description: 'The version override (example: "8.1.2"). Leave blank if you want to make patch release.'
+    default: 'patch'
 
 runs:
   using: 'composite'
@@ -34,7 +42,7 @@ runs:
     ## https://github.com/actions/setup-node/blob/25316bbc1f10ac9d8798711f44914b1cf3c4e954/src/main.ts#L58-L65
     - uses: actions/setup-node@v2.4.0
       with:
-        node-version: 14.x
+        node-version: ${{ inputs.node_version }}
         registry-url: https://registry.npmjs.org
 
     ## The caching steps create a cache key based on the OS and hash of the yarn.lock file. A
@@ -86,15 +94,8 @@ runs:
       run: echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
       shell: bash
 
-    ## On the master branch, we'll do a patch bump on every commit by default.
+    ## Manual version override, patch as default
     - name: Lerna Bump
-      if: '!inputs.version'
-      run: yarn bump --yes patch
-      shell: bash
-
-    ## Manual version override
-    - name: Lerna Bump
-      if: 'inputs.version'
       run: yarn bump --yes ${{inputs.version}}
       shell: bash
 
@@ -135,69 +136,77 @@ runs:
       run: |
         git log -n 1 --decorate=short
       shell: bash
-    ## Build Storybook and extract component stories for Storybook aggregation. This will be used
-    ## for Chromatic rebaselining and publishing to GH Pages. Should be before `yarn build` since
-    ## built assets mess up this command
-    # - name: Build Storybook
-    #   run: |
-    #     yarn build-storybook --quiet
-    #     npx sb extract docs docs/stories.json
-    # ## Build for packaging.
-    # - name: Build
-    #   run: yarn build
-    ## Publish to npm. Must be run after a build
-    # - name: Publish
-    #   run:
-    #     yarn lerna publish from-package --yes --dist-tag ${{steps.extract-branch.outputs.branch ==
-    #     'master' && 'latest' || 'support'}}
-    #   env:
-    #     NODE_AUTH_TOKEN: '${{inputs.publish_token}}'
-    # # Push both the commit and tag created by Lerna's version command using a PAT
-    # - name: Push changes
-    #   uses: ad-m/github-push-action@master
-    #   with:
-    #     github_token: ${{ inputs.gh_rw_token }}
-    #     branch: ${{ github.ref }}
-    #     tags: true
-    # ## Create a release on Github. This will trigger an internal Slack message
-    # - name: Create Release
-    #   uses: actions/create-release@v1
-    #   env:
-    #     GITHUB_TOKEN: ${{ inputs.gh_token }}
-    #   with:
-    #     tag_name: v${{steps.new-tag.outputs.tag}}
-    #     release_name: v${{steps.new-tag.outputs.tag}}
-    #     body: |
-    #       ${{steps.changeset.outputs.body}}
-    #     draft: false
-    #     prerelease: false
-    # ## The master branch is used for static Storybook documentation in the `gh-pages` branch.
-    # - name: Publish Storybook
-    #   if: steps.extract-branch.outputs.branch == 'master'
-    #   uses: JamesIves/github-pages-deploy-action@4.1.5
-    #   with:
-    #     branch: gh-pages
-    #     folder: docs
-    # ## Create a Chromatic baseline auto-accepting changes. Chromatic changes are already accepted
-    # ## in PRs, so we don't need to manually approve them here again. This new baseline will be
-    # ## used for future PRs. New PRs may show extra Chromatic changes until the "Update Branch"
-    # ## button is used in PRs which will pull this new baseline.
-    # - name: Update Chromatic Baseline
-    #   uses: chromaui/action@v1
-    #   with:
-    #     token: ${{ inputs.gh_token }}
-    #     projectToken: ${{ inputs.chromatic_code }}
-    #     storybookBuildDir: docs
-    #     exitOnceUploaded: true
-    #     exitZeroOnChanges: true
-    #     autoAcceptChanges: true
-    # ## Notify Slack of any failures
-    # - name: Report failures
-    #   if: ${{ failure() }}
-    #   run: node utils/report-failure.mjs
-    #   env:
-    #     SLACK_WEBHOOK: ${{ inputs.slack_webhook }}
-    #     TRAVIS_BRANCH: ${{ steps.extract-branch.outputs.branch }}
-    #     TRAVIS_TEST_RESULT: ${{ job.status }}
-    #     TRAVIS_BUILD_URL:
-    #       ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+    # Build Storybook and extract component stories for Storybook aggregation. This will be used
+    # for Chromatic rebaselining and publishing to GH Pages. Should be before `yarn build` since
+    # built assets mess up this command
+    - name: Build Storybook
+      run: |
+        yarn build-storybook --quiet
+        npx sb extract docs docs/stories.json
+
+    ## Build for packaging.
+    - name: Build
+      run: yarn build
+
+    # Publish to npm. Must be run after a build
+    - name: Publish
+      run:
+        yarn lerna publish from-package --yes --dist-tag ${{steps.extract-branch.outputs.branch ==
+        'master' && 'latest' || 'support'}}
+      env:
+        NODE_AUTH_TOKEN: '${{inputs.publish_token}}'
+
+    # Push both the commit and tag created by Lerna's version command using a PAT
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ inputs.gh_rw_token }}
+        branch: ${{ github.ref }}
+        tags: true
+
+    ## Create a release on Github. This will trigger an internal Slack message
+    - name: Create Release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ inputs.gh_token }}
+      with:
+        tag_name: v${{steps.new-tag.outputs.tag}}
+        release_name: v${{steps.new-tag.outputs.tag}}
+        body: |
+          ${{steps.changeset.outputs.body}}
+        draft: false
+        prerelease: false
+
+    ## The master branch is used for static Storybook documentation in the `gh-pages` branch.
+    - name: Publish Storybook
+      if: steps.extract-branch.outputs.branch == 'master'
+      uses: JamesIves/github-pages-deploy-action@4.1.5
+      with:
+        branch: gh-pages
+        folder: docs
+
+    ## Create a Chromatic baseline auto-accepting changes. Chromatic changes are already accepted
+    ## in PRs, so we don't need to manually approve them here again. This new baseline will be
+    ## used for future PRs. New PRs may show extra Chromatic changes until the "Update Branch"
+    ## button is used in PRs which will pull this new baseline.
+    - name: Update Chromatic Baseline
+      uses: chromaui/action@v1
+      with:
+        token: ${{ inputs.gh_token }}
+        projectToken: ${{ inputs.chromatic_code }}
+        storybookBuildDir: docs
+        exitOnceUploaded: true
+        exitZeroOnChanges: true
+        autoAcceptChanges: true
+
+    ## Notify Slack of any failures
+    - name: Report failures
+      if: ${{ failure() }}
+      run: node utils/report-failure.mjs
+      env:
+        SLACK_WEBHOOK: ${{ inputs.slack_webhook }}
+        TRAVIS_BRANCH: ${{ steps.extract-branch.outputs.branch }}
+        TRAVIS_TEST_RESULT: ${{ job.status }}
+        TRAVIS_BUILD_URL:
+          ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/release/action.yml
+++ b/release/action.yml
@@ -105,108 +105,108 @@ runs:
       run: echo "::set-output name=tag::$(node -p 'require("./lerna.json").version')"
       shell: bash
 
-    ## Generate a changeset based on rules of the Canvas Kit repository
-    - name: Generate Changeset
-      uses: Workday/canvas-kit-actions/generate-changeset@v1
-      id: changeset
-      with:
-        token: ${{ inputs.gh_token }}
-        fromRef: v${{steps.previous-tag.outputs.tag}}
-        toRef: ${{steps.extract-branch.outputs.branch}}
-        tagName: v${{steps.new-tag.outputs.tag}}
+    # ## Generate a changeset based on rules of the Canvas Kit repository
+    # - name: Generate Changeset
+    #   uses: Workday/canvas-kit-actions/generate-changeset@v1
+    #   id: changeset
+    #   with:
+    #     token: ${{ inputs.gh_token }}
+    #     fromRef: v${{steps.previous-tag.outputs.tag}}
+    #     toRef: ${{steps.extract-branch.outputs.branch}}
+    #     tagName: v${{steps.new-tag.outputs.tag}}
 
-    ## We could have gone the route of a lerna changeset plugin, but we would lose access to
-    ## usernames which add a nice human touch to release notes
-    - name: Update Changelog
-      run: node utils/update-changelog.js
-      shell: bash
-      env:
-        CHANGESET_TITLE: ${{steps.changeset.outputs.title}}
-        CHANGESET_BODY: |
-          ${{steps.changeset.outputs.body}}
+    # ## We could have gone the route of a lerna changeset plugin, but we would lose access to
+    # ## usernames which add a nice human touch to release notes
+    # - name: Update Changelog
+    #   run: node utils/update-changelog.js
+    #   shell: bash
+    #   env:
+    #     CHANGESET_TITLE: ${{steps.changeset.outputs.title}}
+    #     CHANGESET_BODY: |
+    #       ${{steps.changeset.outputs.body}}
 
-    ## So far, the changes to to the workspace have not been committed. We'll commit them now and
-    ## create a tag
-    - name: Commit and add Tag
-      run: |
-        git add . && git commit -m "chore: Release v${{steps.new-tag.outputs.tag}} [skip release]" && git tag -a v${{steps.new-tag.outputs.tag}} -m "v${{steps.new-tag.outputs.tag}}"
-      shell: bash
+    # ## So far, the changes to to the workspace have not been committed. We'll commit them now and
+    # ## create a tag
+    # - name: Commit and add Tag
+    #   run: |
+    #     git add . && git commit -m "chore: Release v${{steps.new-tag.outputs.tag}} [skip release]" && git tag -a v${{steps.new-tag.outputs.tag}} -m "v${{steps.new-tag.outputs.tag}}"
+    #   shell: bash
 
-    - name: See git log
-      run: |
-        git log -n 1 --decorate=short
-      shell: bash
+    # - name: See git log
+    #   run: |
+    #     git log -n 1 --decorate=short
+    #   shell: bash
 
-    # Build Storybook and extract component stories for Storybook aggregation. This will be used
-    # for Chromatic rebaselining and publishing to GH Pages. Should be before `yarn build` since
-    # built assets mess up this command
-    - name: Build Storybook
-      run: |
-        yarn build-storybook --quiet
-        npx sb extract docs docs/stories.json
+    # # Build Storybook and extract component stories for Storybook aggregation. This will be used
+    # # for Chromatic rebaselining and publishing to GH Pages. Should be before `yarn build` since
+    # # built assets mess up this command
+    # - name: Build Storybook
+    #   run: |
+    #     yarn build-storybook --quiet
+    #     npx sb extract docs docs/stories.json
 
-    ## Build for packaging.
-    - name: Build
-      run: yarn build
+    # ## Build for packaging.
+    # - name: Build
+    #   run: yarn build
 
-    # Publish to npm. Must be run after a build
-    - name: Publish
-      run:
-        yarn lerna publish from-package --yes --dist-tag ${{steps.extract-branch.outputs.branch ==
-        'master' && 'latest' || 'support'}}
-      env:
-        NODE_AUTH_TOKEN: '${{inputs.publish_token}}'
+    # # Publish to npm. Must be run after a build
+    # - name: Publish
+    #   run:
+    #     yarn lerna publish from-package --yes --dist-tag ${{steps.extract-branch.outputs.branch ==
+    #     'master' && 'latest' || 'support'}}
+    #   env:
+    #     NODE_AUTH_TOKEN: '${{inputs.publish_token}}'
 
-    # Push both the commit and tag created by Lerna's version command using a PAT
-    - name: Push changes
-      uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ inputs.gh_rw_token }}
-        branch: ${{ github.ref }}
-        tags: true
+    # # Push both the commit and tag created by Lerna's version command using a PAT
+    # - name: Push changes
+    #   uses: ad-m/github-push-action@master
+    #   with:
+    #     github_token: ${{ inputs.gh_rw_token }}
+    #     branch: ${{ github.ref }}
+    #     tags: true
 
-    ## Create a release on Github. This will trigger an internal Slack message
-    - name: Create Release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ inputs.gh_token }}
-      with:
-        tag_name: v${{steps.new-tag.outputs.tag}}
-        release_name: v${{steps.new-tag.outputs.tag}}
-        body: |
-          ${{steps.changeset.outputs.body}}
-        draft: false
-        prerelease: false
+    # ## Create a release on Github. This will trigger an internal Slack message
+    # - name: Create Release
+    #   uses: actions/create-release@v1
+    #   env:
+    #     GITHUB_TOKEN: ${{ inputs.gh_token }}
+    #   with:
+    #     tag_name: v${{steps.new-tag.outputs.tag}}
+    #     release_name: v${{steps.new-tag.outputs.tag}}
+    #     body: |
+    #       ${{steps.changeset.outputs.body}}
+    #     draft: false
+    #     prerelease: false
 
-    ## The master branch is used for static Storybook documentation in the `gh-pages` branch.
-    - name: Publish Storybook
-      if: steps.extract-branch.outputs.branch == 'master'
-      uses: JamesIves/github-pages-deploy-action@4.1.5
-      with:
-        branch: gh-pages
-        folder: docs
+    # ## The master branch is used for static Storybook documentation in the `gh-pages` branch.
+    # - name: Publish Storybook
+    #   if: steps.extract-branch.outputs.branch == 'master'
+    #   uses: JamesIves/github-pages-deploy-action@4.1.5
+    #   with:
+    #     branch: gh-pages
+    #     folder: docs
 
-    ## Create a Chromatic baseline auto-accepting changes. Chromatic changes are already accepted
-    ## in PRs, so we don't need to manually approve them here again. This new baseline will be
-    ## used for future PRs. New PRs may show extra Chromatic changes until the "Update Branch"
-    ## button is used in PRs which will pull this new baseline.
-    - name: Update Chromatic Baseline
-      uses: chromaui/action@v1
-      with:
-        token: ${{ inputs.gh_token }}
-        projectToken: ${{ inputs.chromatic_code }}
-        storybookBuildDir: docs
-        exitOnceUploaded: true
-        exitZeroOnChanges: true
-        autoAcceptChanges: true
+    # ## Create a Chromatic baseline auto-accepting changes. Chromatic changes are already accepted
+    # ## in PRs, so we don't need to manually approve them here again. This new baseline will be
+    # ## used for future PRs. New PRs may show extra Chromatic changes until the "Update Branch"
+    # ## button is used in PRs which will pull this new baseline.
+    # - name: Update Chromatic Baseline
+    #   uses: chromaui/action@v1
+    #   with:
+    #     token: ${{ inputs.gh_token }}
+    #     projectToken: ${{ inputs.chromatic_code }}
+    #     storybookBuildDir: docs
+    #     exitOnceUploaded: true
+    #     exitZeroOnChanges: true
+    #     autoAcceptChanges: true
 
-    ## Notify Slack of any failures
-    - name: Report failures
-      if: ${{ failure() }}
-      run: node utils/report-failure.mjs
-      env:
-        SLACK_WEBHOOK: ${{ inputs.slack_webhook }}
-        TRAVIS_BRANCH: ${{ steps.extract-branch.outputs.branch }}
-        TRAVIS_TEST_RESULT: ${{ job.status }}
-        TRAVIS_BUILD_URL:
-          ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    # ## Notify Slack of any failures
+    # - name: Report failures
+    #   if: ${{ failure() }}
+    #   run: node utils/report-failure.mjs
+    #   env:
+    #     SLACK_WEBHOOK: ${{ inputs.slack_webhook }}
+    #     TRAVIS_BRANCH: ${{ steps.extract-branch.outputs.branch }}
+    #     TRAVIS_TEST_RESULT: ${{ job.status }}
+    #     TRAVIS_BUILD_URL:
+    #       ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/src/actions/generateChangeset.ts
+++ b/src/actions/generateChangeset.ts
@@ -14,6 +14,8 @@ async function run() {
 
   const commits = await api.getCommits({base: fromRef, head: toRef})
 
+  console.log("repo:", repo);
+
   const {title, body, date} = getReleaseNotes(owner, repo, commits, tagName)
 
   core.setOutput('title', title)

--- a/src/actions/generateChangeset.ts
+++ b/src/actions/generateChangeset.ts
@@ -14,8 +14,6 @@ async function run() {
 
   const commits = await api.getCommits({base: fromRef, head: toRef})
 
-  console.log("repo:", repo);
-
   const {title, body, date} = getReleaseNotes(owner, repo, commits, tagName)
 
   core.setOutput('title', title)


### PR DESCRIPTION
Release action is a composite version of our release workflow placed in Canvas Kit workflows. This action will do all step to publish version given through inputs (or patch as default). Now we can call this action inside other workflows and prevent having repeated code for every release.