### PR TITLE
feat: Update actions to version supporting node 16

### DIFF
--- a/install/action.yml
+++ b/install/action.yml
@@ -5,7 +5,7 @@ inputs:
   node_version:
     required: false
     description: 'Version of Node'
-    default: '14.x'
+    default: '16.x'
 
 runs:
   using: 'composite'
@@ -13,7 +13,7 @@ runs:
     ## This step installs node and sets up several matchers (regex matching for Github
     ## Annotations). See
     ## https://github.com/actions/setup-node/blob/25316bbc1f10ac9d8798711f44914b1cf3c4e954/src/main.ts#L58-L65
-    - uses: actions/setup-node@v2.4.0
+    - uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node_version }}
         registry-url: https://registry.npmjs.org
@@ -29,14 +29,14 @@ runs:
     ## folders. A cache hit will skip the cache steps
     - name: Cache node modules
       id: yarn-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: node_modules
         key: ${{ runner.os }}-${{ inputs.node_version }}-node-modules-hash-${{ hashFiles('yarn.lock') }}
 
     - name: Cache Cypress
       id: cypress-cache
-      uses: actions/cache/@v2
+      uses: actions/cache@v3
       with:
         path: .cache/cypress
         key: ${{ runner.os }}-${{ inputs.node_version }}-cypress-cache-version-${{ steps.cypress-version.outputs.version }}

--- a/release/action.yml
+++ b/release/action.yml
@@ -119,12 +119,12 @@ runs:
 
     ## Create a release on Github. This will trigger an internal Slack message
     - name: Create Release
-      uses: actions/create-release@v1
+      uses: softprops/action-gh-release@v1
       env:
         GITHUB_TOKEN: ${{ inputs.gh_token }}
       with:
         tag_name: v${{steps.new-tag.outputs.tag}}
-        release_name: v${{steps.new-tag.outputs.tag}}
+        name: v${{steps.new-tag.outputs.tag}}
         body: |
           ${{steps.changeset.outputs.body}}
         draft: false
@@ -133,7 +133,7 @@ runs:
     ## The master branch is used for static Storybook documentation in the `gh-pages` branch.
     - name: Publish Storybook
       if: steps.extract-branch.outputs.branch == 'master'
-      uses: JamesIves/github-pages-deploy-action@4.1.5
+      uses: JamesIves/github-pages-deploy-action@4.4.1
       with:
         branch: gh-pages
         folder: docs
@@ -143,7 +143,7 @@ runs:
     ## used for future PRs. New PRs may show extra Chromatic changes until the "Update Branch"
     ## button is used in PRs which will pull this new baseline.
     - name: Update Chromatic Baseline
-      uses: chromaui/action@v1
+      uses: chromaui/action@main
       with:
         token: ${{ inputs.gh_token }}
         projectToken: ${{ inputs.chromatic_code }}


### PR DESCRIPTION
In this PR the `install` and `release` composite actions have been updated. 

In the `install` action all GitHub actions have been moved to v3 which is using node 16.

In the `release` action: 
- GitHub `create-release` action has been changed to `softprops/action-gh-release@v1` because `create-release` is deprecated and has the last supported node version as v12. 
-`softprops/action-gh-release@v1` has  similar inputs structure and using node 16. 
- `JamesIves/github-pages-deploy-action` and `chromaui/action` have been upgraded to latest version. 