### PR TITLE
chore: Add toRef input to release action

### DIFF
--- a/release/action.yml
+++ b/release/action.yml
@@ -20,7 +20,7 @@ inputs:
     default: 'patch'
   toRef:
     required: false
-    description: 'The latest point for the changelog generation to overide default value as a current branch name. Can be branch name or tag.'
+    description: 'The latest point for the changelog generation to overwrite default value as a current branch name. Can be branch name or tag.'
 
 runs:
   using: 'composite'

--- a/release/action.yml
+++ b/release/action.yml
@@ -16,11 +16,11 @@ inputs:
     description: 'Chromatic project token to deploy a storybook.'
   version:
     required: false
-    description: 'The version override (example: "8.1.2"). Leave blank if you want to make patch release.'
+    description: 'The package version override (example: "8.1.2"). Leave blank if you want to make patch release.'
     default: 'patch'
   toRef:
     required: false
-    description: 'The latest point for the changelog generation to overwrite default value as a current branch name. Can be branch name or tag.'
+    description: 'Git ref that marks the end of changelog generation comparison to overwrite default value. Tag, SHA, or branch'
 
 runs:
   using: 'composite'

--- a/release/action.yml
+++ b/release/action.yml
@@ -18,6 +18,9 @@ inputs:
     required: false
     description: 'The version override (example: "8.1.2"). Leave blank if you want to make patch release.'
     default: 'patch'
+  toRef:
+    required: false
+    description: 'The latest point for the changelog generation to overide default value as a current branch name. Can be branch name or tag.'
 
 runs:
   using: 'composite'
@@ -66,7 +69,7 @@ runs:
       with:
         token: ${{ inputs.gh_token }}
         fromRef: v${{steps.previous-tag.outputs.tag}}
-        toRef: ${{steps.extract-branch.outputs.branch}}
+        toRef: ${{ inputs.toRef || steps.extract-branch.outputs.branch}}
         tagName: v${{steps.new-tag.outputs.tag}}
 
     ## We could have gone the route of a lerna changeset plugin, but we would lose access to


### PR DESCRIPTION
Added `toRef` input to overwrite default value. It allows to prevent a generation of wrong changelog based on the incorrect latest point.