### PR TITLE
chore: Pin Storybook to v6 for extract docs script

### DIFF
--- a/release/action.yml
+++ b/release/action.yml
@@ -98,7 +98,7 @@ runs:
       shell: bash
       run: |
         yarn build-storybook --quiet
-        npx sb extract docs docs/stories.json
+        npx sb@6.5.9 extract docs docs/stories.json
 
     ## Build for packaging.
     - name: Build


### PR DESCRIPTION
## Summary

`npx` is installing the latest version of `sb` (v8) by default, but this requires us to bump to Node 18, which we're not quite ready to do. This should pin it to `6.5.9` (the same version used in Canvas Kit) until we're ready to upgrade.