### PR TITLE
fix: Disable cache

### DIFF
--- a/install/action.yml
+++ b/install/action.yml
@@ -24,27 +24,27 @@ runs:
       id: cypress-version
       run: echo "::set-output name=version::$(node ${{ github.action_path }}/get-cypress-version.js)"
 
-    ## The caching steps create a cache key based on the OS and hash of the yarn.lock file. A
-    ## cache hit will copy files from Github cache into the `node_modules` and `.cache/cypress`
-    ## folders. A cache hit will skip the cache steps
-    - name: Cache node modules
-      id: yarn-cache
-      uses: actions/cache@v3
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-${{ inputs.node_version }}-node-modules-hash-${{ hashFiles('yarn.lock') }}
+    # ## The caching steps create a cache key based on the OS and hash of the yarn.lock file. A
+    # ## cache hit will copy files from Github cache into the `node_modules` and `.cache/cypress`
+    # ## folders. A cache hit will skip the cache steps
+    # - name: Cache node modules
+    #   id: yarn-cache
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: node_modules
+    #     key: ${{ runner.os }}-${{ inputs.node_version }}-node-modules-hash-${{ hashFiles('yarn.lock') }}
 
-    - name: Cache Cypress
-      id: cypress-cache
-      uses: actions/cache@v3
-      with:
-        path: .cache/cypress
-        key: ${{ runner.os }}-${{ inputs.node_version }}-cypress-cache-version-${{ steps.cypress-version.outputs.version }}
+    # - name: Cache Cypress
+    #   id: cypress-cache
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: .cache/cypress
+    #     key: ${{ runner.os }}-${{ inputs.node_version }}-cypress-cache-version-${{ steps.cypress-version.outputs.version }}
 
     ## If both `node_modules` and `.cache/cypress` were cache hits, we're going to skip the `yarn
     ## install` step. This effectively saves up to 3m on a cache hit build.
     - name: Install Packages
-      if: steps.yarn-cache.outputs.cache-hit != 'true' || steps.cypress-cache.outputs.cache-hit != 'true'
+      # if: steps.yarn-cache.outputs.cache-hit != 'true' || steps.cypress-cache.outputs.cache-hit != 'true'
       shell: bash
       run: yarn install --production=false
       env:


### PR DESCRIPTION
We're running into cache issues in Canvas Kit. Disabling for now until we can figure out a better system.