### PR TITLE
chore: Update deprecated GH Actions

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         # with:
         #   persist-credentials: false
       - uses: actions/setup-node@v6

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -21,7 +21,7 @@ jobs:
       ## cache hit will copy files from Github cache into the `node_modules` folder. A cache hit will skip the cache steps
       - name: Cache node modules
         id: yarn-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-hash-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -13,9 +13,9 @@ jobs:
       - uses: actions/checkout@v4
         # with:
         #   persist-credentials: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
 
       ## The caching steps create a cache key based on the OS and hash of the yarn.lock file. A
       ## cache hit will copy files from Github cache into the `node_modules` folder. A cache hit will skip the cache steps

--- a/README.md
+++ b/README.md
@@ -111,22 +111,22 @@ This GitHub Action automates the release or prerelease process, supporting versi
 
 | Input Name            | Required | Default                 | Description                                                                                                                                                           |
 | --------------------- | -------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `buildScript`         | ❌ No    | `yarn build`            | Command to build the package before release. Defaults to `yarn build`.                                                                                                |
-| `changelog`           | ❌ No    | `""`                    | Text for the changelog to include in the release.                                                                                                                     |
-| `commitScript`        | ❌ No    | N/A                     | Command to commit changes (e.g., version bumps, changelogs). If not provided, the commit message defaults to: `"chore: Release <package> v<version> [skip release]"`. |
-| `ghToken`             | ✅ Yes   | N/A                     | GitHub token with read/write permissions for release operations.                                                                                                      |
-| `package`             | ✅ Yes   | N/A                     | The package name for correct versioning.                                                                                                                              |
-| `packagePath`         | ✅ Yes   | N/A                     | Path to the folder of the package to be released.                                                                                                                     |
-| `preid`               | ❌ No    | N/A                     | Preid to specify a prerelease version tag (e.g., `beta`, `rc`).                                                                                                       |
-| `prerelease`          | ❌ No    | `false`                 | Flag to indicate whether this is a prerelease. If `true`, both `preid` and `version` must be provided.                                                                |
-| `releaseScript`       | ❌ No    | `npx changeset publish` | Command to perform the release action (e.g., deploy or publish). Defaults to `npx changeset publish`.                                                                 |
-| `skipCreateChangelog` | ❌ No    | N/A                     | If set to `true`, changelog creation is skipped.                                                                                                                      |
-| `skipCreateTag`       | ❌ No    | `true`                  | If set to `true`, git tag creation (`package@version`) is skipped. Defaults to `true`, as Changeset auto-creates tags.                                                |
-| `skipGithubRelease`   | ❌ No    | N/A                     | If set to `true`, skips creating a GitHub release.                                                                                                                    |
-| `skipPush`            | ❌ No    | N/A                     | If set to `true`, skips pushing the created commit and tag to the origin branch.                                                                                      |
-| `skipTagsPush`        | ❌ No    | N/A                     | If set to `true`, skips pushing the created tags to the origin branch.                                                                                                |
-| `version`             | ✅ Yes   | N/A                     | The version type for the release: `patch`, `minor`, or `major`.                                                                                                       |
-| `versionScript`       | ❌ No    | `npx changeset version` | Command to bump the package version. Defaults to `npx changeset version`.                                                                                             |
+| `buildScript`         | ❌ No     | `yarn build`            | Command to build the package before release. Defaults to `yarn build`.                                                                                                |
+| `changelog`           | ❌ No     | `""`                    | Text for the changelog to include in the release.                                                                                                                     |
+| `commitScript`        | ❌ No     | N/A                     | Command to commit changes (e.g., version bumps, changelogs). If not provided, the commit message defaults to: `"chore: Release <package> v<version> [skip release]"`. |
+| `ghToken`             | ✅ Yes    | N/A                     | GitHub token with read/write permissions for release operations.                                                                                                      |
+| `package`             | ✅ Yes    | N/A                     | The package name for correct versioning.                                                                                                                              |
+| `packagePath`         | ✅ Yes    | N/A                     | Path to the folder of the package to be released.                                                                                                                     |
+| `preid`               | ❌ No     | N/A                     | Preid to specify a prerelease version tag (e.g., `beta`, `rc`).                                                                                                       |
+| `prerelease`          | ❌ No     | `false`                 | Flag to indicate whether this is a prerelease. If `true`, both `preid` and `version` must be provided.                                                                |
+| `releaseScript`       | ❌ No     | `npx changeset publish` | Command to perform the release action (e.g., deploy or publish). Defaults to `npx changeset publish`.                                                                 |
+| `skipCreateChangelog` | ❌ No     | N/A                     | If set to `true`, changelog creation is skipped.                                                                                                                      |
+| `skipCreateTag`       | ❌ No     | `true`                  | If set to `true`, git tag creation (`package@version`) is skipped. Defaults to `true`, as Changeset auto-creates tags.                                                |
+| `skipGithubRelease`   | ❌ No     | N/A                     | If set to `true`, skips creating a GitHub release.                                                                                                                    |
+| `skipPush`            | ❌ No     | N/A                     | If set to `true`, skips pushing the created commit and tag to the origin branch.                                                                                      |
+| `skipTagsPush`        | ❌ No     | N/A                     | If set to `true`, skips pushing the created tags to the origin branch.                                                                                                |
+| `version`             | ✅ Yes    | N/A                     | The version type for the release: `patch`, `minor`, or `major`.                                                                                                       |
+| `versionScript`       | ❌ No     | `npx changeset version` | Command to bump the package version. Defaults to `npx changeset version`.                                                                                             |
 
 #### Outputs
 
@@ -144,7 +144,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Release package
         uses: Workday/canvas-kit-actions/do-release@v1
@@ -169,7 +169,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Beta Release
         uses: Workday/canvas-kit-actions/do-release@v1

--- a/install/action.yml
+++ b/install/action.yml
@@ -28,14 +28,14 @@ runs:
     # ## folders. A cache hit will skip the cache steps
     # - name: Cache node modules
     #   id: yarn-cache
-    #   uses: actions/cache@v3
+    #   uses: actions/cache@v5
     #   with:
     #     path: node_modules
     #     key: ${{ runner.os }}-${{ inputs.node_version }}-node-modules-hash-${{ hashFiles('yarn.lock') }}
 
     # - name: Cache Cypress
     #   id: cypress-cache
-    #   uses: actions/cache@v3
+    #   uses: actions/cache@v5
     #   with:
     #     path: .cache/cypress
     #     key: ${{ runner.os }}-${{ inputs.node_version }}-cypress-cache-version-${{ steps.cypress-version.outputs.version }}

--- a/install/action.yml
+++ b/install/action.yml
@@ -13,7 +13,7 @@ runs:
     ## This step installs node and sets up several matchers (regex matching for Github
     ## Annotations). See
     ## https://github.com/actions/setup-node/blob/25316bbc1f10ac9d8798711f44914b1cf3c4e954/src/main.ts#L58-L65
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node_version }}
 


### PR DESCRIPTION
## Issue

Resolves #38

## Summary

This PR updates deprecated GH Actions that run on Node 20 and will be removed on June 16th. This also bumps us up to use Node 24.

1. Updates actions/setup-node from v4 to v6 and Node 24 ([see docs](https://github.com/actions/checkout#checkout-v6))
2. Updates actions/checkout from v4 to v6 ([see docs](https://github.com/actions/checkout#checkout-v6))
3. Updates actions/cache from v3 and v4 to v5 ([see docs](https://github.com/actions/checkout#checkout-v6))

---

<!-- For the reviewer -->

## Where Should the Reviewer Start?

The changes in the action files are pretty straight-forward, but if you want to understand each change better, I'd look at the docs for each action (linked above).

## Testing Manually

I don't have a good way to test these until we run them, unfortunately.

## Thank You GIF

![ship it squirell gif](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExeWhhdHo0cm8zaHRoczYxN3NocmJyZDJ5dnUybGFoZjl1Y212bm9jcyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/NytMLKyiaIh6VH9SPm/giphy.gif)
